### PR TITLE
People posting nonunicode characters makes me sad

### DIFF
--- a/habitat_transition/app.py
+++ b/habitat_transition/app.py
@@ -113,7 +113,10 @@ def payload_telemetry():
 
     if string_type == "base64":
         string = base64.b64decode(string)
-    elif string_type == "ascii-stripped":
+    elif string_type == "ascii" or string_type == "ascii-stripped":
+        string = string.encode("utf8")
+
+    if string_type == "ascii-stripped":
         string += "\n"
 
     assert callsign and string


### PR DESCRIPTION
```
ERROR from logger habitat_transition.app (thread MainThread)

Time:       2014-12-14 10:09:31,706
Location:   /home/habitat/venv/local/lib/python2.7/site-packages/flask/app.py:1306
Module:     app
Function:   log_exception

Exception on /payload_telemetry [POST]
Traceback (most recent call last):
  File "/home/habitat/venv/local/lib/python2.7/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/habitat/venv/local/lib/python2.7/site-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/habitat/venv/local/lib/python2.7/site-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/habitat/venv/local/lib/python2.7/site-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/habitat/venv/local/lib/python2.7/site-packages/habitat_transition/app.py", line 124, in payload_telemetry
    u.payload_telemetry(string, metadata, time_created)
  File "/home/habitat/venv/local/lib/python2.7/site-packages/habitat/uploader.py", line 222, in payload_telemetry
    doc_id = self._payload_telemetry_update(string, receiver_info)
  File "/home/habitat/venv/local/lib/python2.7/site-packages/habitat/uploader.py", line 233, in _payload_telemetry_update
    doc_id = hashlib.sha256(base64.b64encode(string)).hexdigest()
  File "/usr/lib/python2.7/base64.py", line 53, in b64encode
    encoded = binascii.b2a_base64(s)[:-1]
UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd' in position 8: ordinal not in range(128)
```

I've been resisting fixing this for a while because
- this thing is deprecated and shouldn't even be used (people /do/ use it though)
- this is only a problem if you upload non-ascii characters, in which case one should really be using base64 mode

but the error emails are becoming quite boring.
