### PR TITLE
removed internal_temperature as default field

### DIFF
--- a/habitat_transition/spacenearus.py
+++ b/habitat_transition/spacenearus.py
@@ -126,7 +126,6 @@ class SpaceNearUs:
             "time": "time",
             "heading": "heading",
             "speed": "speed",
-            "temp_inside": "temperature_internal",
             "seq": "sentence_id"
         }
 


### PR DESCRIPTION
I don't see a reason to keep` internal_temperature`/`temp_inside` as a separate column in pg. It should be part of `data` JSON as every other telemetry channel.

I've already removed the code processing it in` track.php`. 

Tracker won't have a problem, as `datanew.php` moves `temp_inside` into `data` JSON.

This should be good for deployment.