### PR TITLE
Add tdiff data to listener telemetry for use in filtering.

### DIFF
--- a/habitat_transition/app.py
+++ b/habitat_transition/app.py
@@ -207,6 +207,7 @@ def listener_map(callsign, data):
             "lat": telemetry["latitude"],
             "lon": telemetry["longitude"],
             "alt": telemetry["altitude"],
+            "tdiff_hours": tdiff_hours,
             "description": HTML_DESCRIPTION.format(**info)
         }
     except KeyError:


### PR DESCRIPTION
This will help in being able to filter receivers based on their age on the Habhub tracker.